### PR TITLE
Deploy through github integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,30 +20,9 @@ jobs:
       - run: 
           name: Lint
           command: npm run eslint
-  deploy: 
-    docker:
-      - image: circleci/node:10.15
-    steps: 
-      - checkout
-      - run: 
-          name: Install Now
-          command: npm install --production now
-      - run:
-           name: Deploy
-           command: $(npm bin)/now --token $ZEIT_NOW_TOKEN 
-      - run: 
-            name: Create Alias
-            command: $(npm bin)/now alias --token $ZEIT_NOW_TOKEN
 
 workflows:
   version: 2
-  test_and_deploy:
+  test:
     jobs:
       - lint
-      - deploy:
-          requires:
-            - lint
-          filters:
-            branches:
-              only:
-                - master


### PR DESCRIPTION
This change disables deployment from CircleCI in favor of auto-deploy from the Now github integration.