### PR TITLE
Share using valid HTML IDs

### DIFF
--- a/components/LargeCard.jsx
+++ b/components/LargeCard.jsx
@@ -32,13 +32,14 @@ export const LargeCard = ({
   buttonText
 }) => {
   const tracking = useTracking();
+  const htmlId = `_${id}`;
 
   return (
     <ModalContextConsumer>
       {({ openModal }) => (
         <div className="wcp-large-card-wrapper">
           <section
-            id={id}
+            id={htmlId}
             className={`wcp-large-card ${className} wcp-large-card--${cardOrientation}`}
           >
             <div className="wcp-large-card__cover-image__container">
@@ -66,7 +67,10 @@ export const LargeCard = ({
                     shareCard(
                       {
                         title,
-                        url: getImageShareUrl(window.location.href, `#${id}`)
+                        url: getImageShareUrl(
+                          window.location.href,
+                          `#${htmlId}`
+                        )
                       },
                       openModal
                     );


### PR DESCRIPTION
History of the Worldcup cards have HTML IDs that start
with a number (the year), which is invalid. As a result,
the printer service is unable to extract the specific
element being shared and errors out.

This change generates a new HTML ID based on the fact
id with a leading underscore to ensure it is valid.

Bug: https://trello.com/c/SzW9u9gG/4-share-feature-shares-a-broken-url