### PR TITLE
Don't fail when a fact card image is not found

### DIFF
--- a/components/FactCardSimple.jsx
+++ b/components/FactCardSimple.jsx
@@ -64,8 +64,6 @@ const FactCardSimpleContents = ({ cardData, openModal, closeModal }) => {
     }
   };
 
-  const cloudinaryUrl = getCloudinaryUrl(cardData.facts[0].value.image.url);
-
   return (
     <section className="wcp-fact-card-simple">
       <SectionTitle>{cardData.title}</SectionTitle>
@@ -74,7 +72,9 @@ const FactCardSimpleContents = ({ cardData, openModal, closeModal }) => {
           <div
             className="wcp-fact-card-simple__image"
             style={{
-              backgroundImage: `url(${cloudinaryUrl})`
+              backgroundImage: `url(${getCloudinaryUrl(
+                cardData.facts[0].value.image.url
+              )})`
             }}
           />
         ) : null}

--- a/static/content/en/afghanistan_national_cricket_team.json
+++ b/static/content/en/afghanistan_national_cricket_team.json
@@ -76,7 +76,7 @@
             "label": "Rashid Khan",
             "url": "/read/en/rashid_khan",
             "image": {
-              "url": "",
+              "url": "/static/images/default_person.svg",
               "altText": "Image of Rashid Khan"
             }
           }

--- a/static/content/en/rashid_khan.json
+++ b/static/content/en/rashid_khan.json
@@ -2,7 +2,7 @@
   "title": "Rashid Khan",
   "wikipediaUrl": "https://en.wikipedia.org/wiki/Rashid_Khan_(cricketer)",
   "coverImage": {
-    "url": "-",
+    "url": "/static/images/default_person.svg",
     "altText": "Image of Rashid Khan"
   },
   "summary": "Rashid Khan Arman, commonly known as Rashid Khan, is an Afghan cricketer and the current Twenty20 International (T20I) captain of the national team.",


### PR DESCRIPTION
The FactCard component was already trying to handle a fact
that has no associated image but resolving the URL
(a few lines up) was breaking. I think this change
restores the intent of the code when there is no image.
We cannot really use a placeholder image in this situation
since this a generic component that is reused for players,
venues, events, etc.

Also had placeholder images for Rashid Khan.

Bug: https://trello.com/c/rlgSoRJK/17-500-error-on-page-https-cricketinfoio-read-en-rashidkhan